### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/functionapp-ams.tf
+++ b/functionapp-ams.tf
@@ -21,7 +21,6 @@ module "ams_function_app" {
   common_tags         = var.common_tags
   env                 = var.env
 
-  # app_insights_key = azurerm_application_insights.appinsight.instrumentation_key
   app_settings = {
     "ALGO"                              = "['RS256']"
     "AZURE_CLIENT_ID"                   = data.azuread_application.appreg.application_id

--- a/modules/function_app/main.tf
+++ b/modules/function_app/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_windows_function_app" "this" {
   tags = var.common_tags
 
   site_config {
-    application_insights_connection_string = "InstrumentationKey=${azurerm_application_insights.appinsight.instrumentation_key};IngestionEndpoint=https://uksouth-0.in.applicationinsights.azure.com/"
+    application_insights_connection_string = "InstrumentationKey=${module.application_insights.instrumentation_key};IngestionEndpoint=https://uksouth-0.in.applicationinsights.azure.com/"
   }
 
   identity {
@@ -69,7 +69,7 @@ resource "azurerm_linux_function_app" "this" {
   tags = var.common_tags
 
   site_config {
-    application_insights_connection_string = "InstrumentationKey=${azurerm_application_insights.appinsight.instrumentation_key};IngestionEndpoint=https://uksouth-0.in.applicationinsights.azure.com/"
+    application_insights_connection_string = "InstrumentationKey=${module.application_insights.instrumentation_key};IngestionEndpoint=https://uksouth-0.in.applicationinsights.azure.com/"
     application_stack {
       node_version = "18"
     }
@@ -101,10 +101,18 @@ resource "azurerm_storage_account" "this" {
   allow_nested_items_to_be_public = false
 }
 
-resource "azurerm_application_insights" "appinsight" {
-  application_type    = "web"
-  location            = var.location
-  name                = "${var.product}-${var.name}-${var.env}"
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}-${var.name}"
+
   resource_group_name = data.azurerm_resource_group.rg.name
-  tags                = var.common_tags
+
+  common_tags = var.common_tags
+}
+moved {
+  from = azurerm_application_insights.appinsight
+  to   = module.application_insights.azurerm_application_insights.this
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.