### PR TITLE
Update keyvault data source to reflect new naming

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -3,7 +3,7 @@ data "azurerm_resource_group" "rg" {
 }
 
 data "azurerm_key_vault" "keyvault" {
-  name                = var.env == "prod" ? "${var.product}-hmctskv-${var.env}" : "${var.product}-${var.env}"
+  name                = "${var.product}-hmctskv-${var.env}"
   resource_group_name = data.azurerm_resource_group.rg.name
 }
 


### PR DESCRIPTION
### Change description ###
they're all using hmctskv naming convention now
